### PR TITLE
EM-808: Added rule for C&E upload centre redirect

### DIFF
--- a/conf.d/server.conf.tmpl
+++ b/conf.d/server.conf.tmpl
@@ -140,6 +140,17 @@ server {
     proxy_cache globalcache;
   }
 
+  # For parse upload centre service
+  location /uploadcentre {
+    proxy_pass ${NGINX_PROXY_PARSE};
+
+    # Ensure HTTP get passed thru
+    proxy_pass_request_headers on;
+
+    # its helpful to cache these responses
+    proxy_cache globalcache;
+  }
+
   location / {
     # proxy all traffic to this URL,
     # note the trailing slash strips out the /proxy path on


### PR DESCRIPTION
This adds a redirect for requests directed to **/uploadcentre**  and routes them to the parse service.

No template update is required since the _NGINX_PROXY_PARSE_ environment variable is already available.